### PR TITLE
Initial bower support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,31 @@ A slideout menu plugin for [Reveal.js](https://github.com/hakimel/reveal.js) to 
 
 ## Installation
 
+### Bower
+
+Download and install the package in your project:
+
+```bower install reveal-js-menu```
+
+Add the plugin to the dependencies in your presentation, as below. 
+
+```javascript
+Reveal.initialize({
+	// ...
+	
+	dependencies: [
+		// ... 
+	  
+		{ src: 'bower_components/reveal-js-menu/menu.js' }
+	],
+	menu: {
+		path: 'bower_components/reveal-js-menu'
+	}
+});
+```
+
+### Manual
+
 Copy this repository into the plugins folder of your reveal.js presentation, ie ```plugins/menu```.
 
 Add the plugin to the dependencies in your presentation, as below. 

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,21 @@
+{
+  "name": "reveal.js-menu",
+  "version": "0.2.0",
+  "homepage": "https://github.com/denehyg/reveal.js-menu",
+  "authors": [
+    "Greg Denehy"
+  ],
+  "description": "slideout menu plugin for Reveal.js to quickly jump to any slide by title",
+  "keywords": [
+    "reveal",
+    "menu"
+  ],
+  "license": "Copyright (C) 2015 Greg Denehy",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
Initial bower package (issue #1).
I am new with reveal and its plugins system, so this is the minimal version.
However, I guess that dependencies such as Font Awesome should be managed by bower as well.