### PR TITLE
Custom menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,20 @@ Reveal.initialize({
 		// Use 'true' or format string (same as reveal.js slide numbers)
 		numbers: false,
 
+		// For slide without heading show default title in menu.
+		// Set to 'false' to only list slides with titles.
+		showDefaultTitles: true;
+
 		// Add markers to the slide titles to indicate the 
 		// progress through the presentation
 		markers: false,
+
+		// Add custom panels to be included in the menu.
+		// Set to 'false' if no custom panel shall be added.
+		custom: [
+			{ title: 'Links', icon: '<i class="fa fa-external-link">', src: 'links.html' },
+			{ title: 'About', icon: '<i class="fa fa-info">', content: '<p>This slidedeck is created with reveal.js</p>' }
+		],
 
 		// Specifies the themes that will be available in the themes
 		// menu panel. Set to 'false' to hide themes panel.
@@ -138,7 +149,7 @@ If not explicitly specified (as above), the title will be taken from the first h
 ```
 
 ###### 4. No title is provided
-If no title can be found using the above methods, a default title incorporating the slide number will be used. For example, the following would result in a slide title in the format of 'Slide 12'...
+If no title can be found using the above methods, a default title incorporating the slide number will be used if the option ```showDefaultTitles``` is set to ```true```. For example, the following would result in a slide title in the format of 'Slide 12'...
 
 ```html
 <section>
@@ -146,6 +157,7 @@ If no title can be found using the above methods, a default title incorporating 
 </section>
 ```
 
+If the option ```showDefaultTitles``` is set to ```false```, the slide is not listed in the menu.
 
 ## License
 

--- a/menu.css
+++ b/menu.css
@@ -154,10 +154,19 @@
 	visibility: hidden;
 	height: calc(100% - 60px);
 	overflow-y: auto;
+	color: #848484;
 }
 
 .reveal .slide-menu-panel.active-menu-panel {
 	visibility: visible;
+}
+
+.reveal .slide-menu-panel a {
+	color: white;
+}
+
+.reveal .slide-menu-panel a:hover {
+	background-color: #222;
 }
 
 /*

--- a/menu.js
+++ b/menu.js
@@ -22,7 +22,9 @@ var RevealMenu = window.RevealMenu || (function(){
 			//
 			var side = options.side || 'left';	// 'left' or 'right'
 			var numbers = options.numbers || false;
+			var showDefaultTitles = options.showDefaultTitles || false;
 			var markers = options.markers || false;
+			var custom = options.custom;
 			var themes = options.themes;
 			if (typeof themes === "undefined") {
 				themes = [
@@ -265,6 +267,15 @@ var RevealMenu = window.RevealMenu || (function(){
 				.appendTo(toolbar)
 				.addClass('active-toolbar-button')
 				.click(openPanel);
+			if (custom) {
+				custom.forEach(function(element, index, array) {
+					$('<li data-panel="Custom' + index + '" data-button="' + (buttons++) + '" class="toolbar-panel-button"><span class="slide-menu-toolbar-label">' + element.title + '</span><br/>' + element.icon + '</i></li>')
+						.appendTo(toolbar)
+						.click(openPanel);
+				})
+			}
+
+
 			if (themes) {
 				$('<li data-panel="Themes" data-button="' + (buttons++) + '" class="toolbar-panel-button"><span class="slide-menu-toolbar-label">Themes</span><br/><i class="fa fa-desktop"></i></li>')
 					.appendTo(toolbar)
@@ -293,6 +304,7 @@ var RevealMenu = window.RevealMenu || (function(){
 					$('.menu-title', section).text() ||
 					$('h1, h2, h3, h4, h5, h6', section).text();
 				if (!title) {
+					if (!showDefaultTitles) return '';
 					title = "Slide " + i;
 					type += ' no-title';
 				}
@@ -394,6 +406,43 @@ var RevealMenu = window.RevealMenu || (function(){
 
 			Reveal.addEventListener('slidechanged', highlightCurrentSlide);
 			highlightCurrentSlide();
+
+			// Custom menu
+			//
+			if (custom) {
+				custom.forEach(function(element, index, array) {
+					var panel = $('<div data-panel="Custom' + index + '" class="slide-menu-panel"></div>');
+					if (element.content) {
+						$(element.content).appendTo(panel);
+					}
+					if (element.src) {
+						var xhr = new XMLHttpRequest();
+						xhr.onreadystatechange = function() {
+							if( xhr.readyState === 4 ) {
+								// file protocol yields status code 0 (useful for local debug, mobile applications etc.)
+								if ( ( xhr.status >= 200 && xhr.status < 300 ) || xhr.status === 0 ) {
+									$(xhr.responseText).appendTo(panel);
+								}
+								else {
+									content = 'ERROR: The attempt to fetch ' + url + ' failed with HTTP status ' + xhr.status + '.' +
+										'Check your browser\'s JavaScript console for more details.' +
+										'<p>Remember that you need to serve the presentation HTML from a HTTP server.</p>';
+								}
+							}
+						};
+
+						xhr.open( 'GET', element.src, false );
+						try {
+							xhr.send();
+						}
+						catch ( e ) {
+							alert( 'Failed to get file ' + element.src + '. Make sure that the presentation and the file are served by a HTTP server and the file can be found there. ' + e );
+						}
+
+					}
+					panel.appendTo(panels);
+				})
+			}
 
 			//
 			// Themes


### PR DESCRIPTION
Thanks a lot for this beautiful plugin!

This pull request contains 2 changes:

1. An additional option ```showDefaultTitles``` to enable/disable showing default titles such as 'Slide 12'
2. The possibility to add custom panels that are either provided through external files or parameters.

Example:

The code 
```
...
custom: [
	{ title: 'Sessions', icon: '<i class="fa fa-external-link">', src: 'toc.html' },
	{ title: 'About', icon: '<i class="fa fa-info">', content: '<p class="slide-menu-item">Instructions:<br>Press '?' for keyboard shortcuts. To obtain a PDF-file of the slides you can use the print dialog in Google Chrome (this may not work for other browsers).</p>' }
],
...
```
creates these custom menus:

![screenshot from 2015-09-04 17 42 27](https://cloud.githubusercontent.com/assets/4448455/9687934/7e729068-532c-11e5-90f3-d0e464c59461.png)

The updated Readme.md explains how to  customize the plugin. 