### PR TITLE
bug fix: no error thrown in openMenu() when theme options set to false

### DIFF
--- a/menu.js
+++ b/menu.js
@@ -296,10 +296,12 @@ var RevealMenu = window.RevealMenu || (function(){
 				    select('.slide-menu').classList.add('active');
 				    select('.slide-menu-overlay').classList.add('active');
 					
-				    // identify active theme
+					// identify active theme
+					if (themes) {
 				    selectAll('div[data-panel="Themes"] li').forEach(function(i) { i.classList.remove('active') });
 				    selectAll('li[data-theme="' + select('#theme').getAttribute('href') + '"]').forEach(function(i) { i.classList.add('active') });
-
+					}
+					
 				    // identify active transition
 				    selectAll('div[data-panel="Transitions"] li').forEach(function(i) { i.classList.remove('active') });
 				    selectAll('li[data-transition="' + Reveal.getConfig().transition + '"]').forEach(function(i) { i.classList.add('active') });


### PR DESCRIPTION
Just added another 
```
if (themes) {
    ...
}
```
to prevent a loading error (`Cannot read property 'getAttribute' of null`) when menu is opened while Themes options is set to false.