### PR TITLE
Fix scriptPath

### DIFF
--- a/menu.js
+++ b/menu.js
@@ -909,11 +909,11 @@ var RevealMenu = window.RevealMenu || (function(){
 		// obtain plugin path from the script element
 		var path;
 		if (document.currentScript) {
-			path = document.currentScript.src.slice(0, -7);
+			path = document.currentScript.src.slice(0, -8);
 		} else {
 			var sel = document.querySelector('script[src$="/menu.js"]')
 			if (sel) {
-				path = sel.src.slice(0, -7);
+				path = sel.src.slice(0, -8);
 			}
 		}
 		return path;


### PR DESCRIPTION
This avoids double slashes in path in loadResource(), which causes 403 error if site is deployed on AWS S3.

e.g. `http://example.com/example.path/plugin/reveal.js-menu//menu.css`

I've uploaded gh-pages branch to http://pallxk.s3-website-us-east-1.amazonaws.com/reveal.js-menu/, where the problem can be observed.

And the patched version to http://pallxk.s3-website-us-east-1.amazonaws.com/reveal.js-menu-patched/.