### PR TITLE
Location of demo and plugin source added to docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,4 +6,5 @@ When reporting a bug make sure to include information about which browser and op
 ### Pull Requests
 - Should follow the coding style of the file you work in
 - Should be made towards the **dev branch**
+- Unminified plugin source code lives in plugin.js
 - Should be submitted from a feature/topic branch (not your master)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # reveal.js-menu
 
-A slideout menu plugin for [Reveal.js](https://github.com/hakimel/reveal.js) to quickly jump to any slide by title. Also optionally change the theme and set the default transition. [Check out the live demo](https://denehyg.github.io/reveal.js-menu)
+A slideout menu plugin for [Reveal.js](https://github.com/hakimel/reveal.js) to quickly jump to any slide by title. Also optionally change the theme and set the default transition. [Check out the live demo](https://denehyg.github.io/reveal.js-menu).  The source code for the demo can be found in the **gh-pages branch**.
 
 ## Installation
 


### PR DESCRIPTION
I added notes to the documentation indicating where the demo and plugin source code can be found.  Hopefully this will save you from additional stupid issues opened by people like me.