### PR TITLE
Hide menu button

### DIFF
--- a/menu.css
+++ b/menu.css
@@ -339,8 +339,8 @@
 /*
  * Hide menu for pdf printing
  */
-body.print-pdf .slide-menu-wrapper .slide-menu,
-body.print-pdf .reveal .slide-menu-button,
-body.print-pdf .slide-menu-wrapper .slide-menu-overlay {
+.print-pdf .slide-menu-wrapper .slide-menu,
+.print-pdf .reveal .slide-menu-button,
+.print-pdf .slide-menu-wrapper .slide-menu-overlay {
   display: none;
 }


### PR DESCRIPTION
Bug fix:  The menu button does not hide in print pdf mode.

The css had `body.print-pdf` but in my version of revealjs, the actual css was `html.print-pdf`.  Changing the menu button to this setting fixed the bug.