### PR TITLE
Fix : Do not display menu in print view

### DIFF
--- a/menu.css
+++ b/menu.css
@@ -341,6 +341,9 @@
  */
 body.print-pdf .slide-menu-wrapper .slide-menu,
 body.print-pdf .reveal .slide-menu-button,
-body.print-pdf .slide-menu-wrapper .slide-menu-overlay {
+body.print-pdf .slide-menu-wrapper .slide-menu-overlay,
+html.print-pdf .slide-menu-wrapper .slide-menu,
+html.print-pdf .reveal .slide-menu-button,
+html.print-pdf .slide-menu-wrapper .slide-menu-overlay {
   display: none;
 }


### PR DESCRIPTION
The `print-pdf` class in on the html tag. I left the selector for the body element for compatibility (i assume the class was on body before).