### PR TITLE
scriptPath() should not fail when menu.js is included in a bundle

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -30,7 +30,7 @@ const Plugin = () => {
       if (sel) {
         path = sel.src.slice(0, -7);
       }
-    } else {
+    } else if ('url' in import.meta) {
       path = import.meta.url.slice(0, import.meta.url.lastIndexOf('/') + 1);
     }
 


### PR DESCRIPTION
Since import.meta.url is a runtime feature, it will not exist if the menu.js code is bundled. This change updates scriptPath() to check if import.meta.url exists before trying to dereferencing it, enabling the calculation of options.path to fallback to 'plugin/menu/'.