### PR TITLE
Allow imports from modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "url": "https://github.com/denehyg/reveal.js-menu/issues"
   },
   "homepage": "https://github.com/denehyg/reveal.js-menu#readme",
+  "main": "menu.js",
+  "module": "main.esm.js",
   "devDependencies": {
     "@babel/core": "^7.10.4",
     "@babel/preset-env": "^7.10.4",


### PR DESCRIPTION
Without specifying "main" or "module" in package.json, reveal.js-menu cannot be imported from a module.